### PR TITLE
WorldIndicators: data method should return dataframe with dtype float

### DIFF
--- a/whstudy/world_data_api.py
+++ b/whstudy/world_data_api.py
@@ -115,7 +115,7 @@ class WorldIndicators:
                     cols.append(f"{y}-{i}")
 
         # Create appropriate pandas Dataframe
-        df = pd.DataFrame(data=None, index=countries, columns=cols)
+        df = pd.DataFrame(data=None, index=countries, columns=cols, dtype=float)
 
         # Fill Dataframe from local database
         collection = self.db.countries


### PR DESCRIPTION
Since data frame in data method is initialized to empty data frame columns' dtypes are set to object dtype. When transforming that data frame to Orange Table with `table_from_frame` those columns are not parsed as numeric type (ContinousVariable).

Changing dtype to float.